### PR TITLE
Fix field indices

### DIFF
--- a/config/S2nDwcMeta.xml
+++ b/config/S2nDwcMeta.xml
@@ -38,12 +38,12 @@
     <field index="31" term="http://rs.tdwg.org/dwc/terms/preparations" /> 
     <field index="32" term="http://rs.tdwg.org/dwc/terms/recordedBy" /> 
     <field index="33" term="http://rs.tdwg.org/dwc/terms/license" /> 
-    <field index="35" term="http://rs.tdwg.org/dwc/terms/fieldNumber" />
-    <field index="36" term="http://rs.tdwg.org/dwc/terms/higherGeography" />
-    <field index="37" term="http://rs.tdwg.org/dwc/terms/waterBody" />
-    <field index="38" term="http://rs.tdwg.org/dwc/terms/month" />
-    <field index="39" term="http://rs.tdwg.org/dwc/terms/day" />
-    <field index="40" term="http://rs.tdwg.org/dwc/terms/year" />
+    <field index="34" term="http://rs.tdwg.org/dwc/terms/fieldNumber" />
+    <field index="35" term="http://rs.tdwg.org/dwc/terms/higherGeography" />
+    <field index="36" term="http://rs.tdwg.org/dwc/terms/waterBody" />
+    <field index="37" term="http://rs.tdwg.org/dwc/terms/month" />
+    <field index="38" term="http://rs.tdwg.org/dwc/terms/day" />
+    <field index="39" term="http://rs.tdwg.org/dwc/terms/year" />
   </core>
 
   <!--extension encoding="ISO-8859-1" fieldsTerminatedBy="," linesTerminatedBy="\n" fieldsEnclosedBy='"' ignoreHeaderLines="1" rowType="http://rs.tdwg.org/dwc/terms/Identification">


### PR DESCRIPTION
The old version was missing index 34 so everything was off by one and any reference to the "year" field threw an index error on the cache side since index 40 did not exist.

This should address #1067 and #1066