### PR TITLE
add determiners join table between det and agent.

### DIFF
--- a/config/backstop/dialog_defs.xml
+++ b/config/backstop/dialog_defs.xml
@@ -67,6 +67,7 @@
     <dialog type="display" view="DisposalAgent"    name="DisposalAgentDisplay"  class="edu.ku.brc.specify.datamodel.DisposalAgent" helpcontext="CBXQViewEdit"/>
     <dialog type="display" view="DisposalPreparation"         name="DisposalPreparationDisplay"        class="edu.ku.brc.specify.datamodel.DisposalPreparation" helpcontext="CBXQViewEdit"/>
     <dialog type="display" view="Determination"      name="DeterminationDisplay"     class="edu.ku.brc.specify.datamodel.Determination" helpcontext="CBXQViewEdit"/>
+    <dialog type="display" view="Determiner"          name="DeterminerDisplay"         class="edu.ku.brc.specify.datamodel.Determiner" helpcontext="CBXQViewEdit"/>
     <dialog type="display" view="Division"           name="DivisionDisplay"          class="edu.ku.brc.specify.datamodel.Division" helpcontext="CBXQViewEdit"/>
     <dialog type="display" view="DNAPrimer"          name="DNAPrimerDisplay"         class="edu.ku.brc.specify.datamodel.DNAPrimer" helpcontext="CBXQViewEdit"/>
     <dialog type="display" view="ExchangeInPrep"     name="ExchangeInPrepDisplay"    class="edu.ku.brc.specify.datamodel.ExchangeInPrep" helpcontext="CBXQViewEdit"/>

--- a/config/common/common.views.xml
+++ b/config/common/common.views.xml
@@ -501,6 +501,30 @@
             </altviews>
         </view>
 
+        <view name="Determiner"
+              class="edu.ku.brc.specify.datamodel.Determiner"
+              busrules="edu.ku.brc.specify.datamodel.busrules.DeterminerBusRules"
+        >
+            <desc><![CDATA[The Determiners Form.]]></desc>
+            <altviews>
+                <altview name="Determiner View" viewdef="Determiner" mode="view" validated="false" default="true"/>
+                <altview name="Determiner Edit" viewdef="Determiner" mode="edit" validated="true"/>
+            </altviews>
+        </view>
+
+        <view name="Determiners"
+              class="edu.ku.brc.specify.datamodel.Determiner"
+              busrules="edu.ku.brc.specify.datamodel.busrules.DeterminerBusRules"
+        >
+            <desc><![CDATA[The Determiners Subform.]]></desc>
+            <altviews>
+                <!-- <altview name="Determiners Icon View"  viewdef="DeterminersIconView" mode="view"/>
+                <altview name="Determiners Icon Edit"  viewdef="DeterminersIconView" mode="edit"/>  -->
+                <altview name="Determiners Table View" viewdef="Determiners Table"   mode="view"/>
+                <altview name="Determiners Table Edit" viewdef="Determiners Table"   mode="edit" default="true"/>
+            </altviews>
+        </view>
+
         <view name="DNAPrimer"
               objtitle="DNA Primer"
               class="edu.ku.brc.specify.datamodel.DNAPrimer"
@@ -646,7 +670,7 @@
         <view name="Extractor"
               class="edu.ku.brc.specify.datamodel.Extractor"
               busrules="edu.ku.brc.specify.datamodel.busrules.ExtractorBusRules">
-            <desc><![CDATA[The Collectors Form.]]></desc>
+            <desc><![CDATA[The Extractors Form.]]></desc>
             <altviews>
                 <altview name="Extractor View" viewdef="Extractor" mode="view" validated="false" default="true"/>
                 <altview name="Extractor Edit" viewdef="Extractor" mode="edit" validated="true"/>
@@ -980,7 +1004,7 @@
         <view name="PcrPerson"
               class="edu.ku.brc.specify.datamodel.PcrPerson"
               busrules="edu.ku.brc.specify.datamodel.busrules.PcrPersonBusRules">
-            <desc><![CDATA[The Collectors Form.]]></desc>
+            <desc><![CDATA[The PCRPersons Form.]]></desc>
             <altviews>
                 <altview name="PcrPerson View" viewdef="PcrPerson" mode="view" validated="false" default="true"/>
                 <altview name="PcrPerson Edit" viewdef="PcrPerson" mode="edit" validated="true"/>
@@ -3520,6 +3544,98 @@
             </rows>
         </viewdef>
 
+
+        <viewdef
+                type="form"
+                name="Determiner"
+                class="edu.ku.brc.specify.datamodel.Determiner"
+                gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+                settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+            <desc><![CDATA[The Determiner form.]]></desc>
+            <enableRules/>
+
+            <columnDef>105px,2px,210px,5px,100px,2px,98px,300px,p:g</columnDef>
+            <columnDef os="lnx">135px,2px,230px,5px,120px,2px,118px,325px,p:g</columnDef>
+            <columnDef os="mac">130px,2px,215px,5px,140px,2px,138px,395px,p:g</columnDef>
+            <columnDef os="exp">p,2px,p:g,5px:g,p,2px,p:g,p:g(2),p:g</columnDef>
+            <rowDef>p,2dlu,p:g,2dlu,p:g</rowDef>
+
+            <rows>
+                <row>
+                    <cell type="label" labelfor="1"/>
+                    <cell type="field" id="1" name="agent" uitype="querycbx" initialize="name=Agent;title=Agent"/>
+                </row>
+                <row>
+                    <cell type="label" labelfor="3"/>
+                    <cell type="field" id="3" name="remarks" uitype="textareabrief" rows="2" colspan="6"/>
+                </row>
+                <!--<row>
+                    <cell type="label" labelfor="9"/>
+                    <cell type="field" id="9" name="createdByAgent" uitype="label" readonly="true"  uifieldformatter="Agent"/>
+                    <cell type="label" labelfor="10"/>
+                    <cell type="field" id="10" name="modifiedByAgent" uitype="label" readonly="true"  uifieldformatter="Agent"/>
+                    <cell type="label" id="divLabel" label=" " initialize="align=right"/>
+                    <cell type="field" id="4" name="divisionCBX" uitype="combobox" ignore="true"/>
+                </row>
+                <row>
+                	<cell type="field" id="34" uitype="checkbox" name="isPrimary"/>                	
+                </row>
+                <row>
+                    <cell type="label" labelfor="11"/>
+                    <cell type="field" id="11" name="timestampModified" uitype="label" readonly="true"/>
+                    <cell type="label" labelfor="12"/>
+                    <cell type="field" id="12" name="timestampCreated" uitype="label" readonly="true"/>
+                </row>-->
+            </rows>
+        </viewdef>
+
+        <viewdef
+                type="formtable"
+                name="Determiners Table"
+                class="edu.ku.brc.specify.datamodel.Determiner"
+                gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+                settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+            <desc><![CDATA[Determiners grid view for Determination form.]]></desc>
+            <definition>Determiners</definition>
+        </viewdef>
+
+        <viewdef
+                type="iconview"
+                name="DeterminersIconView"
+                class="edu.ku.brc.specify.datamodel.Determiner"
+                gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+                settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+            <desc><![CDATA[The Determiners Icon Viewer]]></desc>
+        </viewdef>
+
+        <viewdef
+                type="form"
+                name="Determiners"
+                class="edu.ku.brc.specify.datamodel.Determiner"
+                gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+                settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+            <desc><![CDATA[The Determiners form - UNKNOWN use in database.]]></desc>
+            <enableRules/>
+
+            <columnDef>p,5dlu,p:g,5dlu,p</columnDef>
+            <rowDef auto="true" cell="p" sep="2px"/>
+
+            <rows>
+                <row>
+                    <cell type="label" labelfor="3"/>
+                    <cell type="field" id="3" name="agent.lastName" uitype="text" colspan="3"/>
+                </row>
+                <row>
+                    <cell type="label" labelfor="5"/>
+                    <cell type="field" id="5" name="agent.firstName" uitype="text" colspan="3"/>
+                </row>
+                <row>
+                    <cell type="label" labelfor="7"/>
+                    <cell type="field" id="7" name="remarks" uitype="text" colspan="3"/>
+                </row>
+            </rows>
+        </viewdef>
+
         <viewdef
                 name="DNAPrimer"
                 type="form"
@@ -4598,7 +4714,7 @@
                 class="edu.ku.brc.specify.datamodel.Extractor"
                 gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
                 settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
-            <desc><![CDATA[Collectors grid view for CollectingEvent form.]]></desc>
+            <desc><![CDATA[Extractors grid view for CollectingEvent form.]]></desc>
             <definition>PcrPersons</definition>
         </viewdef>
 
@@ -6537,7 +6653,7 @@
                 class="edu.ku.brc.specify.datamodel.PcrPerson"
                 gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
                 settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
-            <desc><![CDATA[Collectors grid view for CollectingEvent form.]]></desc>
+            <desc><![CDATA[PrcPersons grid view for CollectingEvent form.]]></desc>
             <definition>PcrPersons</definition>
         </viewdef>
 

--- a/config/querybuilder.xml
+++ b/config/querybuilder.xml
@@ -120,10 +120,10 @@
     
     <table name="CollectingEvent">
     	<alias name="Locality"/>
-	    <table name="Collector" field="collectors">
-             <alias name="Agent"/>
-             <alias name="Agent" field="createdByAgent" />
-        	 <alias name="Agent" field="modifiedByAgent" />
+	<table name="Collector" field="collectors">
+          <alias name="Agent"/>
+          <alias name="Agent" field="createdByAgent" />
+          <alias name="Agent" field="modifiedByAgent" />
         </table>
         <table name="CollectingEventAttachment" field="collectingEventAttachments">
             <alias name="Attachment"/>
@@ -318,6 +318,12 @@
         <table name="DeterminationCitation" field="determinationCitations">
         	<alias name="ReferenceWork"/>
         </table>
+	<table name="Determiner" field="determiners">
+          <alias name="Agent"/>
+          <alias name="Agent" field="createdByAgent" />
+          <alias name="Agent" field="modifiedByAgent" />
+        </table>
+        
         <!--<table name="DeterminationStatus" field="status"/>-->
         <alias name="Agent" field="determiner"/>
         <alias name="Agent" field="createdByAgent" />

--- a/config/specify_tableid_listing.xml
+++ b/config/specify_tableid_listing.xml
@@ -2,7 +2,7 @@
 
 <!-- 
 
-    Last used ID is 166 or 533
+    Last used ID is 167 or 533
     
     [0] are available
     
@@ -179,6 +179,10 @@
         </table>
         <table name="edu.ku.brc.specify.datamodel.Determination" abbrev="det" id="9" workbench="true" searchable="true">
             <display view="Determination" dataobjformatter="Determination"  searchdlg="DeterminationSearch" newobjdlg="DeterminationDisplay"/>            
+        </table>
+        <table name="edu.ku.brc.specify.datamodel.Determiner" abbrev="detr" id="167" searchable="true">
+            <display view="Determiner" dataobjformatter=""  searchdlg="DeterminerSearch" newobjdlg="DeterminerDisplay"/>
+            <businessrule>edu.ku.brc.specify.datamodel.busrules.DeterminerBusRules</businessrule>
         </table>
         <table name="edu.ku.brc.specify.datamodel.DeterminationCitation" abbrev="detc" id="38" searchable="true"/>
         <table name="edu.ku.brc.specify.datamodel.Discipline" abbrev="dsp" id="26">

--- a/src/edu/ku/brc/specify/datamodel/Attachment.java
+++ b/src/edu/ku/brc/specify/datamodel/Attachment.java
@@ -254,7 +254,7 @@ public class Attachment extends DataModelObjBase implements Serializable
         return Attachment.class;
     }
 
-    @Column(name = "MimeType", length = 64)
+    @Column(name = "MimeType", length = 1024)
     public String getMimeType()
     {
         return this.mimeType;
@@ -280,7 +280,7 @@ public class Attachment extends DataModelObjBase implements Serializable
 		this.isPublic = isPublic;
 	}
 
-    @Column(name = "OrigFilename", nullable = false, length = 20000)
+    @Column(name = "OrigFilename", nullable = false, length = 65536)
     public String getOrigFilename()
     {
         return this.origFilename;

--- a/src/edu/ku/brc/specify/datamodel/CollectingEventAttribute.java
+++ b/src/edu/ku/brc/specify/datamodel/CollectingEventAttribute.java
@@ -134,7 +134,7 @@ public class CollectingEventAttribute extends DisciplineMember implements Clonea
         return number9;
     }
 
-    @Column(name = "Text16", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text16", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText16()
     {
         return text16;
@@ -303,7 +303,7 @@ public class CollectingEventAttribute extends DisciplineMember implements Clonea
 		this.integer10 = integer10;
 	}
 
-    @Column(name = "Text17", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text17", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText17()
     {
         return text17;
@@ -377,13 +377,13 @@ public class CollectingEventAttribute extends DisciplineMember implements Clonea
         return remarks;
     }
 
-    @Column(name = "Text14", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text14", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText14()
     {
         return text14;
     }
 
-    @Column(name = "Text15", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text15", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText15()
     {
         return text15;
@@ -396,13 +396,13 @@ public class CollectingEventAttribute extends DisciplineMember implements Clonea
         return text1;
     }
 
-    @Column(name = "Text10", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text10", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText10()
     {
         return text10;
     }
 
-    @Column(name = "Text11", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text11", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText11()
     {
         return text11;
@@ -434,37 +434,37 @@ public class CollectingEventAttribute extends DisciplineMember implements Clonea
         return text5;
     }
 
-    @Column(name = "Text6", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text6", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText6()
     {
         return text6;
     }
 
-    @Column(name = "Text7", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text7", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText7()
     {
         return text7;
     }
 
-    @Column(name = "Text8", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text8", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText8()
     {
         return text8;
     }
 
-    @Column(name = "Text9", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text9", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText9()
     {
         return text9;
     }
 
-    @Column(name = "Text12", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text12", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText12()
     {
         return text12;
     }
 
-    @Column(name = "Text13", unique = false, nullable = true, insertable = true, updatable = true, length = 50)
+    @Column(name = "Text13", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getText13()
     {
         return text13;

--- a/src/edu/ku/brc/specify/datamodel/ConservDescription.java
+++ b/src/edu/ku/brc/specify/datamodel/ConservDescription.java
@@ -78,6 +78,16 @@ public class ConservDescription extends DataModelObjBase implements AttachmentOw
     protected Boolean yesNo3;
     protected Boolean yesNo4;
     protected Boolean yesNo5;
+    protected Integer integer1;
+    protected Integer integer2;
+    protected Integer integer3;
+    protected Integer integer4;
+    protected Integer integer5;
+    protected BigDecimal number1;
+    protected BigDecimal number2;
+    protected BigDecimal number3;
+    protected BigDecimal number4;
+    protected BigDecimal number5;
 
     protected CollectionObject   collectionObject;
     protected Preparation        preparation;
@@ -136,6 +146,17 @@ public class ConservDescription extends DataModelObjBase implements AttachmentOw
         yesNo3 = null;
         yesNo4 = null;
         yesNo5 = null;
+        integer1 = null;
+        integer2 = null;
+        integer3 = null;
+        integer4 = null;
+        integer5 = null;
+        number1 = null;
+        number2 = null;
+        number3 = null;
+        number4 = null;
+        number5 = null;
+
     }
 
     // End Initializer
@@ -496,6 +517,142 @@ public class ConservDescription extends DataModelObjBase implements AttachmentOw
         this.yesNo5 = yesNo5;
     }
     
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer1", unique = false, nullable = true, insertable = true, updatable = true, length = 24)
+    public Integer getInteger1()
+    {
+        return this.integer1;
+    }
+
+    public void setInteger1(Integer integer1)
+    {
+        this.integer1 = integer1;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer2", unique = false, nullable = true, insertable = true, updatable = true, length = 24)
+    public Integer getInteger2()
+    {
+        return this.integer2;
+    }
+
+    public void setInteger2(Integer integer2)
+    {
+        this.integer2 = integer2;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer3", unique = false, nullable = true, insertable = true, updatable = true, length = 34)
+    public Integer getInteger3()
+    {
+        return this.integer3;
+    }
+
+    public void setInteger3(Integer integer3)
+    {
+        this.integer3 = integer3;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer4", unique = false, nullable = true, insertable = true, updatable = true, length = 44)
+    public Integer getInteger4()
+    {
+        return this.integer4;
+    }
+
+    public void setInteger4(Integer integer4)
+    {
+        this.integer4 = integer4;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer5", unique = false, nullable = true, insertable = true, updatable = true, length = 54)
+    public Integer getInteger5()
+    {
+        return this.integer5;
+    }
+
+    public void setInteger5(Integer integer5)
+    {
+        this.integer5 = integer5;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number1", unique = false, nullable = true, insertable = true, updatable = true, length = 24, precision = 20, scale = 10)
+    public BigDecimal getNumber1() 
+    {
+        return this.number1;
+    }
+    
+    public void setNumber1(BigDecimal number1) 
+    {
+        this.number1 = number1;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number2", unique = false, nullable = true, insertable = true, updatable = true, length = 24, precision = 20, scale = 10)
+    public BigDecimal getNumber2() 
+    {
+        return this.number2;
+    }
+    
+    public void setNumber2(BigDecimal number2) 
+    {
+        this.number2 = number2;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number3", unique = false, nullable = true, insertable = true, updatable = true, length = 34, precision = 20, scale = 10)
+    public BigDecimal getNumber3()
+    {
+        return this.number3;
+    }
+
+    public void setNumber3(BigDecimal number3)
+    {
+        this.number3 = number3;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number4", unique = false, nullable = true, insertable = true, updatable = true, length = 44, precision = 20, scale = 10)
+    public BigDecimal getNumber4()
+    {
+        return this.number4;
+    }
+
+    public void setNumber4(BigDecimal number4)
+    {
+        this.number4 = number4;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number5", unique = false, nullable = true, insertable = true, updatable = true, length = 54, precision = 20, scale = 10)
+    public BigDecimal getNumber5()
+    {
+        return this.number5;
+    }
+
+    public void setNumber5(BigDecimal number5)
+    {
+        this.number5 = number5;
+    }
+
     /**
      *
      */

--- a/src/edu/ku/brc/specify/datamodel/ConservDescription.java
+++ b/src/edu/ku/brc/specify/datamodel/ConservDescription.java
@@ -68,6 +68,17 @@ public class ConservDescription extends DataModelObjBase implements AttachmentOw
     protected String             displayRecommendations;
     protected String             otherRecommendations;
     
+    protected String text1;
+    protected String text2;
+    protected String text3;
+    protected String text4;
+    protected String text5;
+    protected Boolean yesNo1;
+    protected Boolean yesNo2;
+    protected Boolean yesNo3;
+    protected Boolean yesNo4;
+    protected Boolean yesNo5;
+
     protected CollectionObject   collectionObject;
     protected Preparation        preparation;
     protected Division           division;
@@ -115,6 +126,16 @@ public class ConservDescription extends DataModelObjBase implements AttachmentOw
         events               = new HashSet<ConservEvent>();
         conservDescriptionAttachments = new HashSet<ConservDescriptionAttachment>();
 
+        text1 = null;
+        text2 = null;
+        text3 = null;
+        text4 = null;
+        text5 = null;
+        yesNo1 = null;
+        yesNo2 = null;
+        yesNo3 = null;
+        yesNo4 = null;
+        yesNo5 = null;
     }
 
     // End Initializer
@@ -336,6 +357,145 @@ public class ConservDescription extends DataModelObjBase implements AttachmentOw
         this.otherRecommendations = otherRecommendations;
     }
 
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text1", length = 65535)
+    public String getText1() {
+        return this.text1;
+    }
+    
+    public void setText1(String text1) {
+        this.text1 = text1;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text2", length = 65535)
+    public String getText2() {
+        return this.text2;
+    }
+    
+    public void setText2(String text2) {
+        this.text2 = text2;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text3", length = 65535)
+    public String getText3() {
+        return this.text3;
+    }
+    
+    public void setText3(String text3) {
+        this.text3 = text3;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text4", length = 65535)
+    public String getText4() {
+        return this.text4;
+    }
+    
+    public void setText4(String text4) {
+        this.text4 = text4;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text5", length = 65535)
+    public String getText5() {
+        return this.text5;
+    }
+    
+    public void setText5(String text5) {
+        this.text5 = text5;
+    }
+    /**
+     * @return the yesNo1
+     */
+    @Column(name = "YesNo1", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo1() {
+        return yesNo1;
+    }
+
+    /**
+     * @param yesNo1 the yesNo1 to set
+     */
+    public void setYesNo1(Boolean yesNo1) {
+        this.yesNo1 = yesNo1;
+    }
+
+    /**
+     * @return the yesNo2
+     */
+    @Column(name = "YesNo2", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo2() {
+        return yesNo2;
+    }
+
+    /**
+     * @param yesNo2 the yesNo2 to set
+     */
+    public void setYesNo2(Boolean yesNo2) {
+        this.yesNo2 = yesNo2;
+    }
+
+    /**
+     * @return the yesNo3
+     */
+    @Column(name = "YesNo3", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo3() {
+        return yesNo3;
+    }
+
+    /**
+     * @param yesNo3 the yesNo3 to set
+     */
+    public void setYesNo3(Boolean yesNo3) {
+        this.yesNo3 = yesNo3;
+    }
+    
+    /**
+     * @return the yesNo4
+     */
+    @Column(name = "YesNo4", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo4() {
+        return yesNo4;
+    }
+
+    /**
+     * @param yesNo4 the yesNo4 to set
+     */
+    public void setYesNo4(Boolean yesNo4) {
+        this.yesNo4 = yesNo4;
+    }
+
+    /**
+     * @return the yesNo5
+     */
+    @Column(name = "YesNo5", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo5() {
+        return yesNo5;
+    }
+
+    /**
+     * @param yesNo5 the yesNo5 to set
+     */
+    public void setYesNo5(Boolean yesNo5) {
+        this.yesNo5 = yesNo5;
+    }
+    
     /**
      *
      */

--- a/src/edu/ku/brc/specify/datamodel/ConservDescription.java
+++ b/src/edu/ku/brc/specify/datamodel/ConservDescription.java
@@ -88,6 +88,17 @@ public class ConservDescription extends DataModelObjBase implements AttachmentOw
     protected BigDecimal number3;
     protected BigDecimal number4;
     protected BigDecimal number5;
+    protected Calendar                    date1;
+    protected Byte                        date1Precision;
+    protected Calendar                    date2;
+    protected Byte                        date2Precision;
+    protected Calendar                    date3;
+    protected Byte                        date3Precision;
+    protected Calendar                    date4;
+    protected Byte                        date4Precision;
+    protected Calendar                    date5;
+    protected Byte                        date5Precision;
+
 
     protected CollectionObject   collectionObject;
     protected Preparation        preparation;
@@ -156,7 +167,16 @@ public class ConservDescription extends DataModelObjBase implements AttachmentOw
         number3 = null;
         number4 = null;
         number5 = null;
-
+        date1 = null;
+        date1Precision = 1;
+        date2 = null;
+        date2Precision = 1;
+        date3 = null;
+        date3Precision = 1;
+        date4 = null;
+        date4Precision = 1;
+        date5 = null;
+        date5Precision = 1;
     }
 
     // End Initializer
@@ -651,6 +671,181 @@ public class ConservDescription extends DataModelObjBase implements AttachmentOw
     public void setNumber5(BigDecimal number5)
     {
         this.number5 = number5;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Temporal(TemporalType.DATE)
+    @Column(name = "Date1", unique = false, nullable = true, insertable = true, updatable = true)
+    public Calendar getDate1() {
+        return date1;
+    }
+
+    /**
+     *
+     * @param date1
+     */
+    public void setDate1(Calendar date1) {
+        this.date1 = date1;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Column(name = "Date1Precision", unique = false, nullable = true, insertable = true, updatable = true)
+    public Byte getDate1Precision() {
+        return date1Precision;
+    }
+
+    /**
+     *
+     * @param date1Precision
+     */
+    public void setDate1Precision(Byte date1Precision) {
+        this.date1Precision = date1Precision;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Temporal(TemporalType.DATE)
+    @Column(name = "Date2", unique = false, nullable = true, insertable = true, updatable = true)
+    public Calendar getDate2() {
+        return date2;
+    }
+
+    /**
+     *
+     * @param date2
+     */
+    public void setDate2(Calendar date2) {
+        this.date2 = date2;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Column(name = "Date2Precision", unique = false, nullable = true, insertable = true, updatable = true)
+    public Byte getDate2Precision() {
+        return date2Precision;
+    }
+
+    /**
+     *
+     * @param date2Precision
+     */
+    public void setDate2Precision(Byte date2Precision) {
+        this.date2Precision = date2Precision;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Temporal(TemporalType.DATE)
+    @Column(name = "Date3", unique = false, nullable = true, insertable = true, updatable = true)
+    public Calendar getDate3() {
+        return date3;
+    }
+
+    /**
+     *
+     * @param date3
+     */
+    public void setDate3(Calendar date3) {
+        this.date3 = date3;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Column(name = "Date3Precision", unique = false, nullable = true, insertable = true, updatable = true)
+    public Byte getDate3Precision() {
+        return date3Precision;
+    }
+
+    /**
+     *
+     * @param date3Precision
+     */
+    public void setDate3Precision(Byte date3Precision) {
+        this.date3Precision = date3Precision;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Temporal(TemporalType.DATE)
+    @Column(name = "Date4", unique = false, nullable = true, insertable = true, updatable = true)
+    public Calendar getDate4() {
+        return date4;
+    }
+
+    /**
+     *
+     * @param date4
+     */
+    public void setDate4(Calendar date4) {
+        this.date4 = date4;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Column(name = "Date4Precision", unique = false, nullable = true, insertable = true, updatable = true)
+    public Byte getDate4Precision() {
+        return date4Precision;
+    }
+
+    /**
+     *
+     * @param date4Precision
+     */
+    public void setDate4Precision(Byte date4Precision) {
+        this.date4Precision = date4Precision;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Temporal(TemporalType.DATE)
+    @Column(name = "Date5", unique = false, nullable = true, insertable = true, updatable = true)
+    public Calendar getDate5() {
+        return date5;
+    }
+
+    /**
+     *
+     * @param date5
+     */
+    public void setDate5(Calendar date5) {
+        this.date5 = date5;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Column(name = "Date5Precision", unique = false, nullable = true, insertable = true, updatable = true)
+    public Byte getDate5Precision() {
+        return date5Precision;
+    }
+
+    /**
+     *
+     * @param date5Precision
+     */
+    public void setDate5Precision(Byte date5Precision) {
+        this.date5Precision = date5Precision;
     }
 
     /**

--- a/src/edu/ku/brc/specify/datamodel/Container.java
+++ b/src/edu/ku/brc/specify/datamodel/Container.java
@@ -164,7 +164,7 @@ public class Container extends CollectionMember implements java.io.Serializable,
     /**
      *
      */
-    @Column(name = "Name", unique = false, nullable = true, insertable = true, updatable = true, length = 64)
+    @Column(name = "Name", unique = false, nullable = true, insertable = true, updatable = true, length = 1024)
     public String getName() 
     {
         return this.name;
@@ -178,7 +178,7 @@ public class Container extends CollectionMember implements java.io.Serializable,
     /**
      *
      */
-    @Column(name = "Description", unique = false, nullable = true, insertable = true, updatable = true)
+    @Column(name = "Description", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getDescription() 
     {
         return this.description;

--- a/src/edu/ku/brc/specify/datamodel/Determination.java
+++ b/src/edu/ku/brc/specify/datamodel/Determination.java
@@ -33,11 +33,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
 import org.hibernate.annotations.Index;
 
 import edu.ku.brc.af.ui.forms.formatters.UIFieldFormatterIFace;
@@ -104,6 +107,7 @@ public class Determination extends CollectionMember implements java.io.Serializa
      protected CollectionObject    collectionObject;
      protected Set<DeterminationCitation> determinationCitations;
      protected Agent               determiner;
+    protected Set<Determiner>        determiners;
      
 
     // Constructors
@@ -169,6 +173,7 @@ public class Determination extends CollectionMember implements java.io.Serializa
         collectionObject = null;
         determinationCitations = new HashSet<DeterminationCitation>();
         determiner = null;
+        determiners = new HashSet<Determiner>();
         
         hasGUIDField = true;
         setGUID();
@@ -862,6 +867,19 @@ public class Determination extends CollectionMember implements java.io.Serializa
     }
 
 
+    @OneToMany(mappedBy = "determination")
+    @Cascade( {CascadeType.ALL, CascadeType.DELETE_ORPHAN} )
+    @OrderBy("orderNumber ASC")
+    public Set<Determiner> getDeterminers() 
+    {
+        return this.determiners;
+    }
+    
+    public void setDeterminers(Set<Determiner> determiners) 
+    {
+        this.determiners = determiners;
+    }
+
 
 
 
@@ -895,6 +913,7 @@ public class Determination extends CollectionMember implements java.io.Serializa
 //            ds.getId(); // make sure it is loaded;
 //        }
     	determinationCitations.size();
+        determiners.size();
     }
     
     /* (non-Javadoc)
@@ -946,7 +965,8 @@ public class Determination extends CollectionMember implements java.io.Serializa
         obj.determinationId        = null;
         obj.collectionObject       = null;
         obj.determinationCitations = new HashSet<DeterminationCitation>();
-        
+        obj.determiners = new HashSet<Determiner>();
+
         obj.setGUID();
         
         for (DeterminationCitation dc : determinationCitations)
@@ -955,6 +975,14 @@ public class Determination extends CollectionMember implements java.io.Serializa
             newDC.setDetermination(obj);
             obj.determinationCitations.add(newDC);
         }
+
+        for (Determiner determiner : determiners)
+        {
+            Determiner newDeterminer = (Determiner)determiner.clone();
+            newDeterminer.setDetermination(obj);
+            obj.determiners.add(newDeterminer);
+        }
+
          
         return obj;
     }

--- a/src/edu/ku/brc/specify/datamodel/Determiner.java
+++ b/src/edu/ku/brc/specify/datamodel/Determiner.java
@@ -1,0 +1,342 @@
+/* Copyright (C) 2022, Specify Collections Consortium
+ *
+ * Specify Collections Consortium, Biodiversity Institute, University of Kansas,
+ * 1345 Jayhawk Boulevard, Lawrence, Kansas, 66045, USA, support@specifysoftware.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+package edu.ku.brc.specify.datamodel;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import javax.persistence.UniqueConstraint;
+
+import org.apache.commons.lang.StringUtils;
+import org.hibernate.annotations.Index;
+
+import edu.ku.brc.af.core.AppContextMgr;
+import edu.ku.brc.util.Orderable;
+
+
+@Entity
+@org.hibernate.annotations.Entity(dynamicInsert=true, dynamicUpdate=true)
+@org.hibernate.annotations.Proxy(lazy = false)
+@Table(name = "determiner", uniqueConstraints = { @UniqueConstraint(columnNames = {"AgentID", "DeterminationID"}) })
+public class Determiner extends DataModelObjBase implements java.io.Serializable,
+                                                           Orderable,
+                                                           Comparable<Determiner>,
+                                                           Cloneable
+{
+
+    // Fields
+
+     protected Integer         determinerId;
+     protected Integer         orderNumber;
+     protected Boolean         isPrimary;
+     protected String          remarks;
+     protected String text1;
+     protected String text2;
+     protected Boolean yesNo1;
+     protected Boolean yesNo2;
+
+     protected Determination determination;
+     protected Agent           agent;
+
+    // Constructors
+
+    /** default constructor */
+    public Determiner()
+    {
+        //
+    }
+
+    /** constructor with id */
+    public Determiner(Integer determinerId)
+    {
+        this.determinerId = determinerId;
+    }
+
+    // Initializer
+    @Override
+    public void initialize()
+    {
+        super.init();
+        determinerId     = null;
+        orderNumber     = null;
+        isPrimary       = true;
+        remarks         = null;
+        text1 = null;
+        text2 = null;
+        yesNo1 = null;
+        yesNo2 = null;
+        determination = null;
+        agent           = null;
+    }
+    // End Initializer
+
+    // Property accessors
+    @Lob
+    @Column(name = "Text1", length = 65535)
+    public String getText1()
+    {
+        return text1;
+    }
+
+    @Lob
+    @Column(name = "Text2", length = 65535)
+    public String getText2()
+    {
+        return text2;
+    }
+
+    @Column(name = "YesNo1", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo1()
+    {
+        return yesNo1;
+    }
+
+    @Column(name = "YesNo2", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo2()
+    {
+        return yesNo2;
+    }
+
+    public void setText1(String text1) {
+        this.text1 = text1;
+    }
+
+    public void setText2(String text2) {
+        this.text2 = text2;
+    }
+
+    public void setYesNo1(Boolean yesNo1) {
+        this.yesNo1 = yesNo1;
+    }
+
+    public void setYesNo2(Boolean yesNo2) {
+        this.yesNo2 = yesNo2;
+    }
+
+    /**
+     *
+     */
+    @Id
+    @GeneratedValue
+    @Column(name = "DeterminerID")
+    public Integer getDeterminerId()
+    {
+        return this.determinerId;
+    }
+
+    /**
+     * Generic Getter for the ID Property.
+     * @returns ID Property.
+     */
+    @Transient
+    @Override
+    public Integer getId()
+    {
+        return this.determinerId;
+    }
+
+    /* (non-Javadoc)
+     * @see edu.ku.brc.ui.forms.FormDataObjIFace#getDataClass()
+     */
+    @Transient
+    @Override
+    public Class<?> getDataClass()
+    {
+        return Determiner.class;
+    }
+
+    public void setDeterminerId(Integer determinerId) {
+        this.determinerId = determinerId;
+    }
+
+    /**
+     *
+     */
+    @Column(name = "OrderNumber", nullable = false)
+    public Integer getOrderNumber() {
+        return this.orderNumber;
+    }
+
+    public void setOrderNumber(Integer orderNumber) {
+        this.orderNumber = orderNumber;
+    }
+
+    /**
+     * @return the isPrimary
+     */
+    @Column(name = "IsPrimary", unique = false, nullable = false, insertable = true, updatable = true)
+    public Boolean getIsPrimary()
+    {
+        return isPrimary;
+    }
+
+    /**
+     * @param isPrimary the isPrimary to set
+     */
+    public void setIsPrimary(Boolean isPrimary)
+    {
+        this.isPrimary = isPrimary;
+    }
+
+    /**
+     *
+     */
+    @Lob
+    @Column(name = "Remarks", length = 4096)
+    public String getRemarks() {
+        return this.remarks;
+    }
+
+    public void setRemarks(String remarks) {
+        this.remarks = remarks;
+    }
+
+    /**
+     *      * The Determination the agent participated in
+     */
+    @ManyToOne(cascade = {}, fetch = FetchType.LAZY)
+    @JoinColumn(name = "DeterminationID", nullable = false)
+    public Determination getDetermination()
+    {
+        return this.determination;
+    }
+
+    public void setDetermination(Determination determination)
+    {
+        this.determination = determination;
+    }
+
+    /**
+     *      * Link to Determiner's record in Agent table
+     */
+    @ManyToOne(cascade = {}, fetch = FetchType.EAGER)
+    @JoinColumn(name = "AgentID", nullable = false)
+    public Agent getAgent()
+    {
+        return this.agent;
+    }
+
+    public void setAgent(Agent agent) {
+        this.agent = agent;
+    }
+
+    /* (non-Javadoc)
+     * @see edu.ku.brc.specify.datamodel.DataModelObjBase#getIdentityTitle()
+     */
+    @Override
+    @Transient
+    public String getIdentityTitle()
+    {
+        String name = "";
+        if (agent != null)
+        {
+            name = agent.getIdentityTitle();
+        }
+
+        if (StringUtils.isNotEmpty(name))
+        {
+            return name;
+        }
+
+        return super.getIdentityTitle();
+    }
+
+    /* (non-Javadoc)
+     * @see edu.ku.brc.ui.forms.FormDataObjIFace#getTableId()
+     */
+    @Override
+    @Transient
+    public int getTableId()
+    {
+        return getClassTableId();
+    }
+
+    /**
+     * @return the Table ID for the class.
+     */
+    public static int getClassTableId()
+    {
+        return 30;
+    }
+
+    /* (non-Javadoc)
+     * @see edu.ku.brc.util.Orderable#getOrderIndex()
+     */
+    @Transient
+    public int getOrderIndex()
+    {
+        return getOrderNumber();
+    }
+
+    /* (non-Javadoc)
+     * @see edu.ku.brc.util.Orderable#setOrderIndex(int)
+     */
+    public void setOrderIndex(int order)
+    {
+        setOrderNumber(order);
+    }
+
+    /* (non-Javadoc)
+     * @see edu.ku.brc.specify.datamodel.DataModelObjBase#getParentTableId()
+     */
+    @Override
+    @Transient
+    public Integer getParentTableId()
+    {
+        return Determination.getClassTableId();
+    }
+
+    /* (non-Javadoc)
+     * @see edu.ku.brc.specify.datamodel.DataModelObjBase#getParentId()
+     */
+    @Override
+    @Transient
+    public Integer getParentId()
+    {
+        return determination != null ? determination.getId() : null;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Comparable#compareTo(java.lang.Object)
+     */
+    public int compareTo(Determiner obj)
+    {
+        return orderNumber != null && obj != null && obj.orderNumber != null ? orderNumber.compareTo(obj.orderNumber) : 0;
+    }
+
+    /* (non-Javadoc)
+     * @see edu.ku.brc.specify.datamodel.DataModelObjBase#clone()
+     */
+    @Override
+    public Object clone() throws CloneNotSupportedException
+    {
+        Determiner obj = (Determiner)super.clone();
+        obj.setDeterminerId(null);
+        return obj;
+    }
+
+}

--- a/src/edu/ku/brc/specify/datamodel/GeoCoordDetail.java
+++ b/src/edu/ku/brc/specify/datamodel/GeoCoordDetail.java
@@ -76,7 +76,12 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
     protected String                text3;
     protected String                text4;
     protected String                text5;
-    
+    protected Integer               integer1;
+    protected Integer               integer2;
+    protected Integer               integer3;
+    protected Integer               integer4;
+    protected Integer               integer5;
+
     protected Locality              locality;
     
     /**
@@ -124,6 +129,12 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
         text3                 = null;
         text4                 = null;
         text5                 = null;
+
+        integer1 = null;
+        integer2 = null;
+        integer3 = null;
+        integer4 = null;
+        integer5 = null;
         
         locality              = null;
     	//NOTE: if fields are added to this table, the matches method must be updated accordingly!!!! 
@@ -546,6 +557,74 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
     public void setText5(String text5)
     {
         this.text5 = text5;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer1", unique = false, nullable = true, insertable = true, updatable = true, length = 24)
+    public Integer getInteger1()
+    {
+        return this.integer1;
+    }
+
+    public void setInteger1(Integer integer1)
+    {
+        this.integer1 = integer1;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer2", unique = false, nullable = true, insertable = true, updatable = true, length = 24)
+    public Integer getInteger2()
+    {
+        return this.integer2;
+    }
+
+    public void setInteger2(Integer integer2)
+    {
+        this.integer2 = integer2;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer3", unique = false, nullable = true, insertable = true, updatable = true, length = 34)
+    public Integer getInteger3()
+    {
+        return this.integer3;
+    }
+
+    public void setInteger3(Integer integer3)
+    {
+        this.integer3 = integer3;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer4", unique = false, nullable = true, insertable = true, updatable = true, length = 44)
+    public Integer getInteger4()
+    {
+        return this.integer4;
+    }
+
+    public void setInteger4(Integer integer4)
+    {
+        this.integer4 = integer4;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name = "Integer5", unique = false, nullable = true, insertable = true, updatable = true, length = 54)
+    public Integer getInteger5()
+    {
+        return this.integer5;
+    }
+
+    public void setInteger5(Integer integer5)
+    {
+        this.integer5 = integer5;
     }
 
     /**

--- a/src/edu/ku/brc/specify/datamodel/GeoCoordDetail.java
+++ b/src/edu/ku/brc/specify/datamodel/GeoCoordDetail.java
@@ -81,6 +81,11 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
     protected Integer               integer3;
     protected Integer               integer4;
     protected Integer               integer5;
+    protected BigDecimal               number1;
+    protected BigDecimal               number2;
+    protected BigDecimal               number3;
+    protected BigDecimal               number4;
+    protected BigDecimal               number5;
 
     protected Locality              locality;
     
@@ -135,7 +140,13 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
         integer3 = null;
         integer4 = null;
         integer5 = null;
-        
+
+        number1 = null;
+        number2 = null;
+        number3 = null;
+        number4 = null;
+        number5 = null;
+
         locality              = null;
     	//NOTE: if fields are added to this table, the matches method must be updated accordingly!!!! 
     }
@@ -625,6 +636,74 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
     public void setInteger5(Integer integer5)
     {
         this.integer5 = integer5;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number1", unique = false, nullable = true, insertable = true, updatable = true, length = 24, precision = 20, scale = 10)
+    public BigDecimal getNumber1() 
+    {
+        return this.number1;
+    }
+    
+    public void setNumber1(BigDecimal number1) 
+    {
+        this.number1 = number1;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number2", unique = false, nullable = true, insertable = true, updatable = true, length = 24, precision = 20, scale = 10)
+    public BigDecimal getNumber2() 
+    {
+        return this.number2;
+    }
+    
+    public void setNumber2(BigDecimal number2) 
+    {
+        this.number2 = number2;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number3", unique = false, nullable = true, insertable = true, updatable = true, length = 34, precision = 20, scale = 10)
+    public BigDecimal getNumber3()
+    {
+        return this.number3;
+    }
+
+    public void setNumber3(BigDecimal number3)
+    {
+        this.number3 = number3;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number4", unique = false, nullable = true, insertable = true, updatable = true, length = 44, precision = 20, scale = 10)
+    public BigDecimal getNumber4()
+    {
+        return this.number4;
+    }
+
+    public void setNumber4(BigDecimal number4)
+    {
+        this.number4 = number4;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name = "Number5", unique = false, nullable = true, insertable = true, updatable = true, length = 54, precision = 20, scale = 10)
+    public BigDecimal getNumber5()
+    {
+        return this.number5;
+    }
+
+    public void setNumber5(BigDecimal number5)
+    {
+        this.number5 = number5;
     }
 
     /**

--- a/src/edu/ku/brc/specify/datamodel/GeoCoordDetail.java
+++ b/src/edu/ku/brc/specify/datamodel/GeoCoordDetail.java
@@ -86,6 +86,12 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
     protected BigDecimal               number3;
     protected BigDecimal               number4;
     protected BigDecimal               number5;
+    protected Boolean             yesNo1;
+    protected Boolean             yesNo2;
+    protected Boolean             yesNo3;
+    protected Boolean             yesNo4;
+    protected Boolean             yesNo5;
+
 
     protected Locality              locality;
     
@@ -146,6 +152,12 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
         number3 = null;
         number4 = null;
         number5 = null;
+
+        yesNo1 = null;
+        yesNo2 = null;
+        yesNo3 = null;
+        yesNo4 = null;
+        yesNo5 = null;
 
         locality              = null;
     	//NOTE: if fields are added to this table, the matches method must be updated accordingly!!!! 
@@ -705,6 +717,74 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
     {
         this.number5 = number5;
     }
+
+    /**
+     *      * User definable
+     */
+    @Column(name="YesNo1",unique=false,nullable=true,updatable=true,insertable=true)
+    public Boolean getYesNo1() 
+    {
+        return this.yesNo1;
+    }
+    
+    public void setYesNo1(Boolean yesNo1) 
+    {
+        this.yesNo1 = yesNo1;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Column(name="YesNo2",unique=false,nullable=true,updatable=true,insertable=true)
+    public Boolean getYesNo2() 
+    {
+        return this.yesNo2;
+    }
+    
+    public void setYesNo2(Boolean yesNo2) 
+    {
+        this.yesNo2 = yesNo2;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name="YesNo3",unique=false,nullable=true,updatable=true,insertable=true)
+    public Boolean getYesNo3()
+    {
+        return this.yesNo3;
+    }
+
+    public void setYesNo3(Boolean yesNo3)
+    {
+        this.yesNo3 = yesNo3;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name="YesNo4",unique=false,nullable=true,updatable=true,insertable=true)
+    public Boolean getYesNo4()
+    {
+        return this.yesNo4;
+    }
+
+    public void setYesNo4(Boolean yesNo4)
+    {
+        this.yesNo4 = yesNo4;
+    }
+    /**
+     *      * User definable
+     */
+    @Column(name="YesNo5",unique=false,nullable=true,updatable=true,insertable=true)
+    public Boolean getYesNo5()
+    {
+        return this.yesNo5;
+    }
+
+    public void setYesNo5(Boolean yesNo5)
+    {
+        this.yesNo5 = yesNo5;
+    }
+
 
     /**
      * @return the source

--- a/src/edu/ku/brc/specify/datamodel/GeoCoordDetail.java
+++ b/src/edu/ku/brc/specify/datamodel/GeoCoordDetail.java
@@ -74,6 +74,8 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
     protected String                text1;
     protected String                text2;
     protected String                text3;
+    protected String                text4;
+    protected String                text5;
     
     protected Locality              locality;
     
@@ -120,6 +122,8 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
         text1                 = null;
         text2                 = null;
         text3                 = null;
+        text4                 = null;
+        text5                 = null;
         
         locality              = null;
     	//NOTE: if fields are added to this table, the matches method must be updated accordingly!!!! 
@@ -506,6 +510,42 @@ public class GeoCoordDetail extends DataModelObjBase implements Cloneable
     public void setText3(String text3)
     {
         this.text3 = text3;
+    }
+
+    /**
+     * @return the text4
+     */
+    @Lob
+    @Column(name = "Text4", length = 65535)
+    public String getText4()
+    {
+        return text4;
+    }
+
+    /**
+     * @param text4 the text4 to set
+     */
+    public void setText4(String text4)
+    {
+        this.text4 = text4;
+    }
+
+    /**
+     * @return the text5
+     */
+    @Lob
+    @Column(name = "Text5", length = 65535)
+    public String getText5()
+    {
+        return text5;
+    }
+
+    /**
+     * @param text5 the text5 to set
+     */
+    public void setText5(String text5)
+    {
+        this.text5 = text5;
     }
 
     /**

--- a/src/edu/ku/brc/specify/datamodel/Locality.java
+++ b/src/edu/ku/brc/specify/datamodel/Locality.java
@@ -346,7 +346,7 @@ public class Locality extends DisciplineMember implements AttachmentOwnerIFace<L
     /**
      * * The full name of the locality.
      */
-    @Column(name = "LocalityName", unique = false, nullable = false, insertable = true, updatable = true)
+    @Column(name = "LocalityName", unique = false, nullable = false, insertable = true, updatable = true, length=2048)
     public String getLocalityName()
     {
         return this.localityName;

--- a/src/edu/ku/brc/specify/datamodel/Locality.java
+++ b/src/edu/ku/brc/specify/datamodel/Locality.java
@@ -346,7 +346,7 @@ public class Locality extends DisciplineMember implements AttachmentOwnerIFace<L
     /**
      * * The full name of the locality.
      */
-    @Column(name = "LocalityName", unique = false, nullable = false, insertable = true, updatable = true, length=2048)
+    @Column(name = "LocalityName", unique = false, nullable = false, insertable = true, updatable = true, length=1024)
     public String getLocalityName()
     {
         return this.localityName;

--- a/src/edu/ku/brc/specify/datamodel/OtherIdentifier.java
+++ b/src/edu/ku/brc/specify/datamodel/OtherIdentifier.java
@@ -52,6 +52,12 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
      protected String           remarks;
      protected CollectionObject collectionObject;
 
+    protected String text1;
+    protected String text2;
+    protected String text3;
+    protected String text4;
+    protected String text5;
+
 
     // Constructors
 
@@ -79,6 +85,11 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
         institution = null;
         remarks = null;
         collectionObject = null;
+        text1 = null;
+        text2 = null;
+        text3 = null;
+        text4 = null;
+        text5 = null;
     }
     // End Initializer
 
@@ -144,6 +155,70 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
         this.remarks = remarks;
     }
 
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text1", length = 65535)
+    public String getText1() {
+        return this.text1;
+    }
+    
+    public void setText1(String text1) {
+        this.text1 = text1;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text2", length = 65535)
+    public String getText2() {
+        return this.text2;
+    }
+    
+    public void setText2(String text2) {
+        this.text2 = text2;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text3", length = 65535)
+    public String getText3() {
+        return this.text3;
+    }
+    
+    public void setText3(String text3) {
+        this.text3 = text3;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text4", length = 65535)
+    public String getText4() {
+        return this.text4;
+    }
+    
+    public void setText4(String text4) {
+        this.text4 = text4;
+    }
+
+    /**
+     *      * User definable
+     */
+    @Lob
+    @Column(name = "Text5", length = 65535)
+    public String getText5() {
+        return this.text5;
+    }
+    
+    public void setText5(String text5) {
+        this.text5 = text5;
+    }
     /**
      *      * ID of object identified by Identifier
      */

--- a/src/edu/ku/brc/specify/datamodel/OtherIdentifier.java
+++ b/src/edu/ku/brc/specify/datamodel/OtherIdentifier.java
@@ -57,6 +57,11 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
     protected String text3;
     protected String text4;
     protected String text5;
+    protected Boolean yesNo1;
+    protected Boolean yesNo2;
+    protected Boolean yesNo3;
+    protected Boolean yesNo4;
+    protected Boolean yesNo5;
 
 
     // Constructors
@@ -90,6 +95,11 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
         text3 = null;
         text4 = null;
         text5 = null;
+        yesNo1 = null;
+        yesNo2 = null;
+        yesNo3 = null;
+        yesNo4 = null;
+        yesNo5 = null;
     }
     // End Initializer
 
@@ -219,6 +229,81 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
     public void setText5(String text5) {
         this.text5 = text5;
     }
+    /**
+     * @return the yesNo1
+     */
+    @Column(name = "YesNo1", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo1() {
+        return yesNo1;
+    }
+
+    /**
+     * @param yesNo1 the yesNo1 to set
+     */
+    public void setYesNo1(Boolean yesNo1) {
+        this.yesNo1 = yesNo1;
+    }
+
+    /**
+     * @return the yesNo2
+     */
+    @Column(name = "YesNo2", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo2() {
+        return yesNo2;
+    }
+
+    /**
+     * @param yesNo2 the yesNo2 to set
+     */
+    public void setYesNo2(Boolean yesNo2) {
+        this.yesNo2 = yesNo2;
+    }
+
+    /**
+     * @return the yesNo3
+     */
+    @Column(name = "YesNo3", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo3() {
+        return yesNo3;
+    }
+
+    /**
+     * @param yesNo3 the yesNo3 to set
+     */
+    public void setYesNo3(Boolean yesNo3) {
+        this.yesNo3 = yesNo3;
+    }
+    
+    /**
+     * @return the yesNo4
+     */
+    @Column(name = "YesNo4", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo4() {
+        return yesNo4;
+    }
+
+    /**
+     * @param yesNo4 the yesNo4 to set
+     */
+    public void setYesNo4(Boolean yesNo4) {
+        this.yesNo4 = yesNo4;
+    }
+
+    /**
+     * @return the yesNo5
+     */
+    @Column(name = "YesNo5", unique = false, nullable = true, insertable = true, updatable = true)
+    public Boolean getYesNo5() {
+        return yesNo5;
+    }
+
+    /**
+     * @param yesNo5 the yesNo5 to set
+     */
+    public void setYesNo5(Boolean yesNo5) {
+        this.yesNo5 = yesNo5;
+    }
+    
     /**
      *      * ID of object identified by Identifier
      */

--- a/src/edu/ku/brc/specify/datamodel/OtherIdentifier.java
+++ b/src/edu/ku/brc/specify/datamodel/OtherIdentifier.java
@@ -62,6 +62,8 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
     protected Boolean yesNo3;
     protected Boolean yesNo4;
     protected Boolean yesNo5;
+    protected Agent agent1;
+    protected Agent agent2;
 
 
     // Constructors
@@ -100,6 +102,8 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
         yesNo3 = null;
         yesNo4 = null;
         yesNo5 = null;
+        agent1 = null;
+        agent2 = null;
     }
     // End Initializer
 
@@ -304,6 +308,26 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
         this.yesNo5 = yesNo5;
     }
     
+    @ManyToOne(cascade = {}, fetch = FetchType.LAZY)
+    @JoinColumn(name = "Agent1ID", unique = false, nullable = true, insertable = true, updatable = true)
+    public Agent getAgent1() {
+        return agent1;
+    }
+
+    public void setAgent1(Agent agent1) {
+        this.agent1 = agent1;
+    }
+
+    @ManyToOne(cascade = {}, fetch = FetchType.LAZY)
+    @JoinColumn(name = "Agent2ID", unique = false, nullable = true, insertable = true, updatable = true)
+    public Agent getAgent2() {
+        return agent2;
+    }
+
+    public void setAgent2(Agent agent2) {
+        this.agent2 = agent2;
+    }
+
     /**
      *      * ID of object identified by Identifier
      */

--- a/src/edu/ku/brc/specify/datamodel/OtherIdentifier.java
+++ b/src/edu/ku/brc/specify/datamodel/OtherIdentifier.java
@@ -19,16 +19,9 @@
 */
 package edu.ku.brc.specify.datamodel;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import java.util.Calendar;
+
+import javax.persistence.*;
 
 import org.hibernate.annotations.Index;
 
@@ -64,6 +57,10 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
     protected Boolean yesNo5;
     protected Agent agent1;
     protected Agent agent2;
+    protected Calendar                    date1;
+    protected Byte                        date1Precision;
+    protected Calendar                    date2;
+    protected Byte                        date2Precision;
 
 
     // Constructors
@@ -104,6 +101,10 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
         yesNo5 = null;
         agent1 = null;
         agent2 = null;
+        date1 = null;
+        date1Precision = 1;
+        date2 = null;
+        date2Precision = 1;
     }
     // End Initializer
 
@@ -326,6 +327,75 @@ public class OtherIdentifier extends CollectionMember implements java.io.Seriali
 
     public void setAgent2(Agent agent2) {
         this.agent2 = agent2;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Temporal(TemporalType.DATE)
+    @Column(name = "Date1", unique = false, nullable = true, insertable = true, updatable = true)
+    public Calendar getDate1() {
+        return date1;
+    }
+
+    /**
+     *
+     * @param date1
+     */
+    public void setDate1(Calendar date1) {
+        this.date1 = date1;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Column(name = "Date1Precision", unique = false, nullable = true, insertable = true, updatable = true)
+    public Byte getDate1Precision() {
+        return date1Precision;
+    }
+
+    /**
+     *
+     * @param date1Precision
+     */
+    public void setDate1Precision(Byte date1Precision) {
+        this.date1Precision = date1Precision;
+    }
+    /**
+     *
+     * @return
+     */
+    @Temporal(TemporalType.DATE)
+    @Column(name = "Date2", unique = false, nullable = true, insertable = true, updatable = true)
+    public Calendar getDate2() {
+        return date2;
+    }
+
+    /**
+     *
+     * @param date2
+     */
+    public void setDate2(Calendar date2) {
+        date2 = date2;
+    }
+
+    /**
+     *
+     * @return
+     */
+    @Column(name = "Date2Precision", unique = false, nullable = true, insertable = true, updatable = true)
+    public Byte getDate2Precision() {
+        return date2Precision;
+    }
+
+    /**
+     *
+     * @param date2Precision
+     */
+    public void setDate2Precision(Byte date2Precision) {
+        date2Precision = date2Precision;
     }
 
     /**

--- a/src/edu/ku/brc/specify/datamodel/PickListItem.java
+++ b/src/edu/ku/brc/specify/datamodel/PickListItem.java
@@ -127,7 +127,7 @@ public class PickListItem extends DataModelObjBase implements PickListItemIFace,
     /**
      * 
      */
-    @Column(name = "Title", nullable = false, length = 128)
+    @Column(name = "Title", nullable = false, length = 1024)
     public String getTitle()
     {
         return this.title;
@@ -173,7 +173,7 @@ public class PickListItem extends DataModelObjBase implements PickListItemIFace,
     /**
      * 
      */
-    @Column(name = "Value", length = 128)
+    @Column(name = "Value", length = 1024)
     public String getValue()
     {
         return this.value;// == null ? title : (value.equals("|null|") ? null : value);

--- a/src/edu/ku/brc/specify/datamodel/SpLocaleItemStr.java
+++ b/src/edu/ku/brc/specify/datamodel/SpLocaleItemStr.java
@@ -139,7 +139,7 @@ public class SpLocaleItemStr extends DataModelObjBase implements LocalizableStrI
     /**
      * @return the text
      */
-    @Column(name = "Text", unique = false, nullable = false, insertable = true, updatable = true, length = 255)
+    @Column(name = "Text", unique = false, nullable = false, insertable = true, updatable = true, length = 2048)
     public String getText()
     {
         return text;
@@ -150,10 +150,10 @@ public class SpLocaleItemStr extends DataModelObjBase implements LocalizableStrI
      */
     public void setText(String text)
     {
-        if (text != null && text.length() > 255)
+        if (text != null && text.length() > 2048)
         {
-            log.error("String len: "+text.length()+ " is > 255 ["+text+"]");
-            this.text = text.substring(0, 255);
+            log.error("String len: "+text.length()+ " is > 2048 ["+text+"]");
+            this.text = text.substring(0, 2048);
             
         } else
         {

--- a/src/edu/ku/brc/specify/datamodel/SpQueryField.java
+++ b/src/edu/ku/brc/specify/datamodel/SpQueryField.java
@@ -505,7 +505,7 @@ public class SpQueryField extends DataModelObjBase implements Comparable<SpQuery
     /**
      * @return the startValue
      */
-    @Column(name = "StartValue", unique = false, nullable = false, insertable = true, updatable = true, length = 1000)
+    @Column(name = "StartValue", unique = false, nullable = false, insertable = true, updatable = true, length = 65536)
     public String getStartValue()
     {
         return startValue;
@@ -514,7 +514,7 @@ public class SpQueryField extends DataModelObjBase implements Comparable<SpQuery
     /**
      * @return the endValue
      */
-    @Column(name = "EndValue", unique = false, nullable = true, insertable = true, updatable = true, length = 1000)
+    @Column(name = "EndValue", unique = false, nullable = true, insertable = true, updatable = true, length = 65536)
     public String getEndValue()
     {
         return endValue;

--- a/src/edu/ku/brc/specify/datamodel/Workbench.java
+++ b/src/edu/ku/brc/specify/datamodel/Workbench.java
@@ -204,7 +204,7 @@ public class Workbench extends DataModelObjBase implements java.io.Serializable,
     /**
      *      * Name of workbench
      */
-    @Column(name = "Name", length = 64)
+    @Column(name = "Name", length = 256)
     public String getName() {
         return this.name;
     }

--- a/src/edu/ku/brc/specify/datamodel/busrules/DeterminerBusRules.java
+++ b/src/edu/ku/brc/specify/datamodel/busrules/DeterminerBusRules.java
@@ -1,0 +1,81 @@
+/* Copyright (C) 2022, Specify Collections Consortium
+ *
+ * Specify Collections Consortium, Biodiversity Institute, University of Kansas,
+ * 1345 Jayhawk Boulevard, Lawrence, Kansas, 66045, USA, support@specifysoftware.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+package edu.ku.brc.specify.datamodel.busrules;
+
+import static edu.ku.brc.ui.UIRegistry.getResourceString;
+
+import java.util.Hashtable;
+
+import edu.ku.brc.af.core.AppContextMgr;
+import edu.ku.brc.af.ui.forms.BaseBusRules;
+import edu.ku.brc.dbsupport.DataProviderSessionIFace;
+import edu.ku.brc.specify.datamodel.Determination;
+import edu.ku.brc.specify.datamodel.Determiner;
+import edu.ku.brc.specify.datamodel.Division;
+
+public class DeterminerBusRules extends BaseBusRules
+{
+
+    public DeterminerBusRules()
+    {
+        super(Determiner.class);
+    }
+
+    @Override
+    public STATUS processBusinessRules(final Object parentDataObj, final Object dataObj, final boolean isExistingObject)
+    {
+        reasonList.clear();
+
+        // isEdit is false when the data object is new, true when editing an existing object.
+        if (isExistingObject &&
+            parentDataObj instanceof Determination &&
+            dataObj instanceof Determiner)
+        {
+            Determination det = (Determination)parentDataObj;
+            Determiner detr = (Determiner)dataObj;
+
+            Hashtable<Integer, Boolean> hash = new Hashtable<Integer, Boolean>();
+            for (Determiner determiner : det.getDeterminers())
+            {
+                Integer id    = determiner.getAgent().getAgentId();
+                boolean isBad = false;
+                if (hash.get(id) == null)
+                {
+                    if (determiner.getId() != null && id.equals(detr.getAgent().getAgentId()))
+                    {
+                        isBad = true;
+                    }
+                    hash.put(id, true);
+                } else
+                {
+                    isBad = true;
+                }
+
+                if (isBad)
+                {
+                    reasonList.add(String.format(getResourceString("DT_DUPLICATE_DETERMINERS"), detr.getIdentityTitle()));
+                    return STATUS.Error;
+                }
+            }
+        }
+
+        return super.processBusinessRules(parentDataObj, dataObj, isExistingObject);
+    }
+}

--- a/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
+++ b/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
@@ -2813,8 +2813,8 @@ public class SpecifySchemaUpdateService extends SchemaUpdateService
                     frame.incOverall();
 
                     frame.setDesc("Increasing length of Locality.LocalityName");
-                    if (getFieldLength(conn, databaseName, "locality", "LocalityName") != 2048) {
-                        sql = "alter table locality modify column `LocalityName` varchar(2048) not null";
+                    if (getFieldLength(conn, databaseName, "locality", "LocalityName") != 1024) {
+                        sql = "alter table locality modify column `LocalityName` varchar(1024) not null";
                         if (-1 == update(conn, sql)) {
                             errMsgList.add("update error: " + sql);
                             return false;

--- a/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
+++ b/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
@@ -2832,6 +2832,26 @@ public class SpecifySchemaUpdateService extends SchemaUpdateService
                     }
                     frame.incOverall();
 
+                    frame.setDesc("Increasing length of PicklistItem.Title");
+                    if (getFieldLength(conn, databaseName, "picklistitem", "Title") != 1024) {
+                        sql = "alter table picklistitem modify column `Title` varchar(1024) not null";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
+                    frame.setDesc("Increasing length of PicklistItem.Value");
+                    if (getFieldLength(conn, databaseName, "picklistitem", "Value") != 1024) {
+                        sql = "alter table picklistitem modify column `Value` varchar(1024)";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
                     frame.setDesc("Increasing length of Workbench.Name");
                     if (getFieldLength(conn, databaseName, "workbench", "Name") != 256) {
                         sql = "alter table workbench modify column `Name` varchar(256)";

--- a/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
+++ b/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
@@ -2872,6 +2872,26 @@ public class SpecifySchemaUpdateService extends SchemaUpdateService
                     }
                     frame.incOverall();
 
+                    frame.setDesc("Changing SpQueryField.StartValue to text.");
+                    if (!getFieldColumnType(conn, databaseName, "spqueryfield", "StartValue").equalsIgnoreCase("text")) {
+                        sql = "alter table spqueryfield modify column StartValue text(65535)";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
+                    frame.setDesc("Changing SpQueryField.EndValue to text.");
+                    if (!getFieldColumnType(conn, databaseName, "spqueryfield", "EndValue").equalsIgnoreCase("text")) {
+                        sql = "alter table spqueryfield modify column EndValue text(65535)";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
                     frame.setDesc("Increasing length of Attachment.Mimetype");
                     if (getFieldLength(conn, databaseName, "attachment", "MimeType") != 1024) {
                         sql = "alter table attachment modify column `MimeType` varchar(1024)";

--- a/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
+++ b/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
@@ -2822,6 +2822,16 @@ public class SpecifySchemaUpdateService extends SchemaUpdateService
                     }
                     frame.incOverall();
 
+                    frame.setDesc("Increasing length of Workbench.Name");
+                    if (getFieldLength(conn, databaseName, "workbench", "Name") != 256) {
+                        sql = "alter table workbench modify column `Name` varchar(256)";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
                     frame.setDesc("Changing Attachment.origFilename to text.");
                     if (!getFieldColumnType(conn, databaseName, "attachment", "origFilename").equalsIgnoreCase("text")) {
                         sql = "alter table attachment modify column origFilename text(65535) not null";

--- a/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
+++ b/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
@@ -2822,6 +2822,16 @@ public class SpecifySchemaUpdateService extends SchemaUpdateService
                     }
                     frame.incOverall();
 
+                    frame.setDesc("Increasing length of SpLocaleItemStr.Text");
+                    if (getFieldLength(conn, databaseName, "splocaleitemstr", "Text") != 2048) {
+                        sql = "alter table splocaleitemstr modify column `Text` varchar(2048) not null";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
                     frame.setDesc("Increasing length of Workbench.Name");
                     if (getFieldLength(conn, databaseName, "workbench", "Name") != 256) {
                         sql = "alter table workbench modify column `Name` varchar(256)";

--- a/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
+++ b/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
@@ -2822,6 +2822,36 @@ public class SpecifySchemaUpdateService extends SchemaUpdateService
                     }
                     frame.incOverall();
 
+                    frame.setDesc("Increasing size of CollectingEventAttribute.text* fields.");
+                    String[] ceatextfields = {
+                        "Text10",
+                        "Text11",
+                        "Text12",
+                        "Text13",
+                        "Text14",
+                        "Text15",
+                        "Text16",
+                        "Text17",
+                        "Text2",
+                        "Text3",
+                        "Text4",
+                        "Text5",
+                        "Text6",
+                        "Text7",
+                        "Text8",
+                        "Text9"
+                    };
+                    for (String field : ceatextfields) {
+                        if (!getFieldColumnType(conn, databaseName, "collectingeventattribute", field).equalsIgnoreCase("text")) {
+                            sql = "alter table collectingeventattribute modify column " + field + " text(65535)";
+                            if (-1 == update(conn, sql)) {
+                                errMsgList.add("update error: " + sql);
+                                return false;
+                            }
+                        }
+                    }
+                    frame.incOverall();
+                    
                     frame.setProcess(0, 100);
                     return true;
                 } catch (Exception ex)

--- a/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
+++ b/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
@@ -2822,6 +2822,26 @@ public class SpecifySchemaUpdateService extends SchemaUpdateService
                     }
                     frame.incOverall();
 
+                    frame.setDesc("Changing Attachment.origFilename to text.");
+                    if (!getFieldColumnType(conn, databaseName, "attachment", "origFilename").equalsIgnoreCase("text")) {
+                        sql = "alter table attachment modify column origFilename text(65535) not null";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
+                    frame.setDesc("Increasing length of Attachment.Mimetype");
+                    if (getFieldLength(conn, databaseName, "attachment", "MimeType") != 1024) {
+                        sql = "alter table attachment modify column `MimeType` varchar(1024)";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
                     frame.setDesc("Increasing size of CollectingEventAttribute.text* fields.");
                     String[] ceatextfields = {
                         "Text10",

--- a/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
+++ b/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
@@ -2812,6 +2812,15 @@ public class SpecifySchemaUpdateService extends SchemaUpdateService
                     SchemaUpdateService.createDBTablesFromSQLFile(conn, "floats_to_decimals.sql");
                     frame.incOverall();
 
+                    frame.setDesc("Increasing length of Locality.LocalityName");
+                    if (getFieldLength(conn, databaseName, "locality", "LocalityName") != 2048) {
+                        sql = "alter table locality modify column `LocalityName` varchar(2048) not null";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
 
                     frame.setProcess(0, 100);
                     return true;

--- a/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
+++ b/src/edu/ku/brc/specify/dbsupport/SpecifySchemaUpdateService.java
@@ -2842,6 +2842,26 @@ public class SpecifySchemaUpdateService extends SchemaUpdateService
                     }
                     frame.incOverall();
 
+                    frame.setDesc("Changing Container.Description to text.");
+                    if (!getFieldColumnType(conn, databaseName, "container", "Description").equalsIgnoreCase("text")) {
+                        sql = "alter table container modify column Description text(65535)";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
+                    frame.setDesc("Increasing length of Container.Name");
+                    if (getFieldLength(conn, databaseName, "container", "Name") != 1024) {
+                        sql = "alter table container modify column `Name` varchar(1024)";
+                        if (-1 == update(conn, sql)) {
+                            errMsgList.add("update error: " + sql);
+                            return false;
+                        }
+                    }
+                    frame.incOverall();
+
                     frame.setDesc("Increasing size of CollectingEventAttribute.text* fields.");
                     String[] ceatextfields = {
                         "Text10",

--- a/src/hibernate.cfg.xml
+++ b/src/hibernate.cfg.xml
@@ -103,6 +103,7 @@
 		<mapping class="edu.ku.brc.specify.datamodel.DisposalPreparation"/>
 		<mapping class="edu.ku.brc.specify.datamodel.DeterminationCitation"/>
 		<mapping class="edu.ku.brc.specify.datamodel.Determination"/>
+		<mapping class="edu.ku.brc.specify.datamodel.Determiner"/>
 		<!--<mapping class="edu.ku.brc.specify.datamodel.DeterminationStatus"/>-->
 		<mapping class="edu.ku.brc.specify.datamodel.Discipline"/>
 		<mapping class="edu.ku.brc.specify.datamodel.Division"/>

--- a/src/resources_en.properties
+++ b/src/resources_en.properties
@@ -2187,6 +2187,7 @@ CONTAINER_KIDS_ERROR=A container cannot be deleted when it is 'connected' to oth
 
 # Determination
 DT_ALREADY_DETERMINATION=There is already a current Determination.
+DT_DUPLICATE_DETERMINERS=The determiner '%s' can only be used once.
 
 #Disicpline
 CREATEDISP=Create a Discipline

--- a/src/resources_pt.properties
+++ b/src/resources_pt.properties
@@ -2170,6 +2170,7 @@ CONTAINER_KIDS_ERROR=Um recipiente não pode ser apagado quando está 'ligado' a
 
 # Determination
 DT_ALREADY_DETERMINATION=Já existe uma Determinação atual.
+DT_DUPLICATE_DETERMINERS=The determiner '%s' can only be used once.
 
 #Disicpline
 CREATEDISP=Criar uma Disciplina

--- a/src/resources_ru.properties
+++ b/src/resources_ru.properties
@@ -2187,6 +2187,7 @@ CONTAINER_KIDS_ERROR=Контейнер нельзя удалить, когда 
 
 # Determination
 DT_ALREADY_DETERMINATION=Текущее определение уже существует.
+DT_DUPLICATE_DETERMINERS=The determiner '%s' can only be used once.
 
 #Disicpline
 CREATEDISP=Создать Дисциплину

--- a/src/resources_uk.properties
+++ b/src/resources_uk.properties
@@ -2188,6 +2188,7 @@ CONTAINER_KIDS_ERROR=Контейнер можна видалити, коли в
 
 # Determination
 DT_ALREADY_DETERMINATION=Уже є поточне визначення.
+DT_DUPLICATE_DETERMINERS=The determiner '%s' can only be used once.
 
 #Disicpline
 CREATEDISP=Створити дисципліну


### PR DESCRIPTION
for #1131 

This PR adds the Determiners table. I added some common view form defs for the new table, but the determination form in a test database will have to be adjusted to add the determiners as a formtable subview in order to test it out. The new table and the _determiners_ field on determination are hidden in the schema by default.