### PR TITLE
formatted guest/ento.views

### DIFF
--- a/config/insect/guest/ento.views.xml
+++ b/config/insect/guest/ento.views.xml
@@ -2,21 +2,12 @@
 <viewset name="Ento Views" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     
     <views>
-        <view name="EntoAttributes"
-            class="edu.ku.brc.specify.datamodel.CollectionObjectAttribute"
-            resourcelabels="false">
-            <desc><![CDATA[Subform within the Collection Object form.]]></desc>
-            <altviews>
-                <altview name="EntoAttributes View" viewdef="EntoAttributes" mode="view" />
-                <altview name="EntoAttributes Edit" viewdef="EntoAttributes" mode="edit" default="true"/>
-            </altviews>
-        </view>
 
-        <view name="CollectingEvent"
-            class="edu.ku.brc.specify.datamodel.CollectingEvent"
-            busrules="edu.ku.brc.specify.datamodel.busrules.CollectingEventBusRules"
-            isinternal="false"
-            resourcelabels="false">
+		<view name="CollectingEvent"
+			class="edu.ku.brc.specify.datamodel.CollectingEvent"
+			busrules="edu.ku.brc.specify.datamodel.busrules.CollectingEventBusRules"
+			isinternal="false"
+			resourcelabels="false">
             <desc><![CDATA[CollectingEvent Form]]></desc>
             <altviews>
                 <altview name="CollectingEvent View" viewdef="CollectingEvent" mode="view" default="true"/>
@@ -24,23 +15,22 @@
             </altviews>
         </view>
 
-        <view name="CollectingEventSub"
-            class="edu.ku.brc.specify.datamodel.CollectingEvent"
-            busrules="edu.ku.brc.specify.datamodel.busrules.CollectingEventBusRules"
-            resourcelabels="false">
+		<view name="CollectingEventSub"
+			class="edu.ku.brc.specify.datamodel.CollectingEvent"
+			busrules="edu.ku.brc.specify.datamodel.busrules.CollectingEventBusRules"
+			resourcelabels="false">
             <desc><![CDATA[CollectingEvent SubForm]]></desc>
             <altviews>
                 <altview name="CollectingEventSub View" viewdef="CollectingEventSub" mode="view" default="true"/>
                 <altview name="CollectingEventSub Edit" viewdef="CollectingEventSub" mode="edit" />
             </altviews>
         </view>
-        
-        <view name="CollectionObject"
-            class="edu.ku.brc.specify.datamodel.CollectionObject"
-            busrules="edu.ku.brc.specify.datamodel.busrules.CollectionObjectBusRules"
-            isinternal="false"
-            resourcelabels="false"
-            >
+
+		<view name="CollectionObject"
+			class="edu.ku.brc.specify.datamodel.CollectionObject"
+			busrules="edu.ku.brc.specify.datamodel.busrules.CollectionObjectBusRules"
+			isinternal="false"
+			resourcelabels="false">
             <desc><![CDATA[The Collection Object form.]]></desc>
             <altviews>
                 <altview name="Collection Object View" viewdef="Collection Object" mode="view"/>
@@ -48,11 +38,11 @@
             </altviews>
         </view>
 
-        <view name="Determination"
-              class="edu.ku.brc.specify.datamodel.Determination"
-              busrules="edu.ku.brc.specify.datamodel.busrules.DeterminationBusRules" 
-              isexternal="true"
-              resourcelabels="false">
+		<view name="Determination"
+			class="edu.ku.brc.specify.datamodel.Determination"
+			busrules="edu.ku.brc.specify.datamodel.busrules.DeterminationBusRules"
+			isexternal="true"
+			resourcelabels="false">
             <desc><![CDATA[Subform within the Collection Object form.]]></desc>
             <altviews>
                 <altview name="Determination View"       viewdef="Determination" mode="view"/>
@@ -61,28 +51,141 @@
                 <altview name="Determination Table Edit" viewdef="Determination Table" mode="edit"/>
             </altviews>
         </view>
-        
-        <view name="DeterminationViewOnly"
-            class="edu.ku.brc.specify.datamodel.Determination"
-            isexternal="true"
-            resourcelabels="false">
+
+		<view name="DeterminationViewOnly"
+			class="edu.ku.brc.specify.datamodel.Determination"
+			isexternal="true"
+			resourcelabels="false">
             <desc><![CDATA[Subform within the Collection Object form.]]></desc>
             <altviews>
                 <altview name="Determination View"       viewdef="Determination" mode="view" default="true"/>
             </altviews>
         </view>
-                
-    </views>
+
+		<view name="EntoAttributes"
+			class="edu.ku.brc.specify.datamodel.CollectionObjectAttribute"
+			resourcelabels="false">
+            <desc><![CDATA[Subform within the Collection Object form.]]></desc>
+            <altviews>
+                <altview name="EntoAttributes View" viewdef="EntoAttributes" mode="view" />
+                <altview name="EntoAttributes Edit" viewdef="EntoAttributes" mode="edit" default="true"/>
+            </altviews>
+        </view>
+
+	</views>
     
     
     <viewdefs>
-        
-        <viewdef
-            type="form"
-            name="Collection Object"
-            class="edu.ku.brc.specify.datamodel.CollectionObject"
-            gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
-            settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+
+		<viewdef name="CollectingEvent"
+			type="form"
+			class="edu.ku.brc.specify.datamodel.CollectingEvent"
+			gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+			settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+            <desc><![CDATA[Collecting Event]]></desc>
+            
+            <columnDef>100px,2px,200px,5px,90px,2px,210px,5px,96px,2px,115px,0px,15px,p:g</columnDef>
+            <columnDef os="lnx">115px,2px,240px,5px,100px,2px,215px,5px,106px,2px,125px,0px,15px,p:g</columnDef>
+            <columnDef os="mac">130px,2px,251px,5px,130px,2px,270px,5px,130px,2px,130px,0px,15px,p:g</columnDef>
+            <columnDef os="exp">p,2px,max(p;190px),5px:g,p,2px,p,5px:g,p,2px,110px,p,p,p:g</columnDef>
+            <rowDef auto="true" cell="p" sep="2px"/>
+            
+            <rows>
+                <row>
+                    <cell type="label" labelfor="1"/>
+                    <cell type="field" id="1" name="stationFieldNumber" uitype="text"/>
+                    <cell type="label" labelfor="2"/>
+                    <cell type="field" id="2" uitype="plugin" name="this" initialize="name=PartialDateUI;df=startDate;tp=startDatePrecision" uifieldformatter="Date"/>
+                    <cell type="label" labelfor="9"/>
+                    <cell type="field" id="9" name="startTime" uitype="text"/>
+                </row>
+                <row>
+                    <cell type="label" labelfor="3"/>
+                    <cell type="field" id="3" name="method" uitype="combobox"/>
+                    <cell type="label" labelfor="10"/>
+                    <cell type="field" id="10" uitype="plugin" name="this" initialize="name=PartialDateUI;df=endDate;tp=endDatePrecision" uifieldformatter="Date"/>
+                    <cell type="label" labelfor="7"/>
+                    <cell type="field" id="7" name="endTime" uitype="text"/>
+                </row>
+                <row>
+                    <cell type="label" labelfor="4"/>
+                    <cell type="field" id="4" name="locality" uitype="querycbx" initialize="name=Locality;title=Locality" colspan="10"/> 
+                </row>
+                
+                <row>
+                    <cell type="label" labelfor="6"/>
+                    <cell type="field" id="6" name="remarks" uitype="textareabrief" rows="2" colspan="10"/>
+                </row>
+                <row>
+                    <cell type="subview" viewname="Collectors" id="5" name="collectors" colspan="13" rows="3"/>
+                </row>
+                <row>
+                    <cell type="subview" viewname="CollectionObjectSub" id="11" colspan="13" rows="3" name="collectionObjects" initialize="addsearch=true"/>
+                </row>
+                <row>
+                    <cell type="separator" label="Attachments" colspan="13"/>
+                </row>
+                <row>
+                    <cell type="subview" id="attachments" viewname="ObjectAttachment" name="collectingEventAttachments" colspan="13" initialize="btn=true;icon=CollectingEventAttachment"/>
+                </row>
+            </rows>
+        </viewdef>
+
+		<viewdef name="CollectingEventSub"
+			type="form"
+			class="edu.ku.brc.specify.datamodel.CollectingEvent"
+			gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+			settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+            <desc><![CDATA[Collecting Event]]></desc>
+
+            <columnDef>100px,2px,210px,5px,75px,2px,210px,5px,90px,2px,111px,0px,p:g</columnDef>
+            <columnDef os="lnx">115px,2px,210px,5px,105px,2px,210px,5px,125px,2px,136px,0px,p:g</columnDef>
+            <columnDef os="mac">130px,2px,255px,5px,95px,2px,255px,5px,125px,2px,181px,0px,p:g</columnDef>
+            <columnDef os="exp">p,2px,p,5px:g,p,2px,255px,5px:g,p,2px,p:g,0px</columnDef>
+            <rowDef auto="true" cell="p" sep="2px"/>
+            
+            <rows>
+                <row>
+                    <cell type="label" labelfor="5"/>
+                    <cell type="field" id="5" name="stationFieldNumber" uitype="text"/>
+                    <cell type="label" labelfor="3"/>
+                    <cell type="field" id="3" name="method" uitype="combobox"/>
+                    <cell type="label" label=""/>
+                    <cell type="subview" id="1" viewname="ObjectAttachment" name="collectingEventAttachments" initialize="align=right;btn=true;icon=CollectingEventAttachment"/>
+                </row>
+                <row>
+                    <cell type="label" labelfor="7"/>
+                    <cell type="field" id="7" uitype="plugin" name="this" initialize="name=PartialDateUI;df=startDate;tp=startDatePrecision" uifieldformatter="Date"/>
+                    <cell type="label" labelfor="8"/>
+                    <cell type="field" id="8" uitype="plugin" name="this" initialize="name=PartialDateUI;df=endDate;tp=endDatePrecision" uifieldformatter="Date"/>
+                    <cell type="label" labelfor="13"/>
+                    <cell type="field" id="13" name="verbatimDate" uitype="text" colspan="2"/>   
+                </row>
+                <row>
+                    <cell type="label" labelfor="4"/>
+                    <cell type="field" id="4" name="locality" uitype="querycbx" initialize="name=Locality;title=Locality" colspan="10"/> 
+                </row>
+                <row>
+                    <cell type="label" labelfor="6"/>
+                    <cell type="field" id="6" name="remarks" uitype="textareabrief" rows="2" colspan="10" cols="50"/>
+                </row>
+                <row>
+                    <cell type="subview" viewname="Collectors" id="12" name="collectors" colspan="12" rows="3"/>
+                </row>
+                <!--
+                    <row>
+                    <cell type="label" labelfor="geography" label="Geography"/>
+                    <cell type="field" id="geography" name="geography" uitype="querycbx" initialize="name=Geography;title=Geography"/>
+                    </row>
+                -->
+            </rows>
+        </viewdef>
+
+		<viewdef name="Collection Object"
+			type="form"
+			class="edu.ku.brc.specify.datamodel.CollectionObject"
+			gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+			settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
             
             <desc><![CDATA[The Collection Object form.]]></desc>
             <enableRules/>
@@ -142,129 +245,11 @@
             </rows>
         </viewdef>
 
-        <viewdef
-            type="form"
-            name="CollectingEventSub"
-            class="edu.ku.brc.specify.datamodel.CollectingEvent"
-            gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
-            settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
-            <desc><![CDATA[Collecting Event]]></desc>
-
-            <columnDef>100px,2px,210px,5px,75px,2px,210px,5px,90px,2px,111px,0px,p:g</columnDef>
-            <columnDef os="lnx">115px,2px,210px,5px,105px,2px,210px,5px,125px,2px,136px,0px,p:g</columnDef>
-            <columnDef os="mac">130px,2px,255px,5px,95px,2px,255px,5px,125px,2px,181px,0px,p:g</columnDef>
-            <columnDef os="exp">p,2px,p,5px:g,p,2px,255px,5px:g,p,2px,p:g,0px</columnDef>
-            <rowDef auto="true" cell="p" sep="2px"/>
-            
-            <rows>
-                <row>
-                    <cell type="label" labelfor="5"/>
-                    <cell type="field" id="5" name="stationFieldNumber" uitype="text"/>
-                    <cell type="label" labelfor="3"/>
-                    <cell type="field" id="3" name="method" uitype="combobox"/>
-                    <cell type="label" label=""/>
-                    <cell type="subview" id="1" viewname="ObjectAttachment" name="collectingEventAttachments" initialize="align=right;btn=true;icon=CollectingEventAttachment"/>
-                </row>
-                <row>
-                    <cell type="label" labelfor="7"/>
-                    <cell type="field" id="7" uitype="plugin" name="this" initialize="name=PartialDateUI;df=startDate;tp=startDatePrecision" uifieldformatter="Date"/>
-                    <cell type="label" labelfor="8"/>
-                    <cell type="field" id="8" uitype="plugin" name="this" initialize="name=PartialDateUI;df=endDate;tp=endDatePrecision" uifieldformatter="Date"/>
-                    <cell type="label" labelfor="13"/>
-                    <cell type="field" id="13" name="verbatimDate" uitype="text" colspan="2"/>   
-                </row>
-                <row>
-                    <cell type="label" labelfor="4"/>
-                    <cell type="field" id="4" name="locality" uitype="querycbx" initialize="name=Locality;title=Locality" colspan="10"/> 
-                </row>
-                <row>
-                    <cell type="label" labelfor="6"/>
-                    <cell type="field" id="6" name="remarks" uitype="textareabrief" rows="2" colspan="10" cols="50"/>
-                </row>
-                <row>
-                    <cell type="subview" viewname="Collectors" id="12" name="collectors" colspan="12" rows="3"/>
-                </row>
-                <!--
-                    <row>
-                    <cell type="label" labelfor="geography" label="Geography"/>
-                    <cell type="field" id="geography" name="geography" uitype="querycbx" initialize="name=Geography;title=Geography"/>
-                    </row>
-                -->
-            </rows>
-        </viewdef>
-
-        <viewdef
-            type="form"
-            name="CollectingEvent"
-            class="edu.ku.brc.specify.datamodel.CollectingEvent"
-            gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
-            settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
-            <desc><![CDATA[Collecting Event]]></desc>
-            
-            <columnDef>100px,2px,200px,5px,90px,2px,210px,5px,96px,2px,115px,0px,15px,p:g</columnDef>
-            <columnDef os="lnx">115px,2px,240px,5px,100px,2px,215px,5px,106px,2px,125px,0px,15px,p:g</columnDef>
-            <columnDef os="mac">130px,2px,251px,5px,130px,2px,270px,5px,130px,2px,130px,0px,15px,p:g</columnDef>
-            <columnDef os="exp">p,2px,max(p;190px),5px:g,p,2px,p,5px:g,p,2px,110px,p,p,p:g</columnDef>
-            <rowDef auto="true" cell="p" sep="2px"/>
-            
-            <rows>
-                <row>
-                    <cell type="label" labelfor="1"/>
-                    <cell type="field" id="1" name="stationFieldNumber" uitype="text"/>
-                    <cell type="label" labelfor="2"/>
-                    <cell type="field" id="2" uitype="plugin" name="this" initialize="name=PartialDateUI;df=startDate;tp=startDatePrecision" uifieldformatter="Date"/>
-                    <cell type="label" labelfor="9"/>
-                    <cell type="field" id="9" name="startTime" uitype="text"/>
-                </row>
-                <row>
-                    <cell type="label" labelfor="3"/>
-                    <cell type="field" id="3" name="method" uitype="combobox"/>
-                    <cell type="label" labelfor="10"/>
-                    <cell type="field" id="10" uitype="plugin" name="this" initialize="name=PartialDateUI;df=endDate;tp=endDatePrecision" uifieldformatter="Date"/>
-                    <cell type="label" labelfor="7"/>
-                    <cell type="field" id="7" name="endTime" uitype="text"/>
-                </row>
-                <row>
-                    <cell type="label" labelfor="4"/>
-                    <cell type="field" id="4" name="locality" uitype="querycbx" initialize="name=Locality;title=Locality" colspan="10"/> 
-                </row>
-                
-                <row>
-                    <cell type="label" labelfor="6"/>
-                    <cell type="field" id="6" name="remarks" uitype="textareabrief" rows="2" colspan="10"/>
-                </row>
-                <row>
-                    <cell type="subview" viewname="Collectors" id="5" name="collectors" colspan="13" rows="3"/>
-                </row>
-                <row>
-                    <cell type="subview" viewname="CollectionObjectSub" id="11" colspan="13" rows="3" name="collectionObjects" initialize="addsearch=true"/>
-                </row>
-                <row>
-                    <cell type="separator" label="Attachments" colspan="13"/>
-                </row>
-                <row>
-                    <cell type="subview" id="attachments" viewname="ObjectAttachment" name="collectingEventAttachments" colspan="13" initialize="btn=true;icon=CollectingEventAttachment"/>
-                </row>
-            </rows>
-        </viewdef>
-
-        <viewdef
-            type="formtable"
-            name="Determination Table"
-            class="edu.ku.brc.specify.datamodel.Determination"
-            gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
-            settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
-            
-            <desc><![CDATA[Determination subform table for Collection Object form.]]></desc>
-            <definition>Determination</definition>
-        </viewdef>
-        
-        <viewdef
-            name="Determination"
-            type="form"
-            class="edu.ku.brc.specify.datamodel.Determination"
-            gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
-            settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+		<viewdef name="Determination"
+			type="form"
+			class="edu.ku.brc.specify.datamodel.Determination"
+			gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+			settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
             
             <desc><![CDATA[Determination subform for Collection Object form.]]></desc>
             <enableRules/>
@@ -313,12 +298,21 @@
             
         </viewdef>
 
-        <viewdef
-            type="form"
-            name="EntoAttributes"
-            class="edu.ku.brc.specify.datamodel.CollectionObjectAttribute"
-            gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
-            settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+		<viewdef name="Determination Table"
+			type="formtable"
+			class="edu.ku.brc.specify.datamodel.Determination"
+			gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+			settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
+            
+            <desc><![CDATA[Determination subform table for Collection Object form.]]></desc>
+            <definition>Determination</definition>
+        </viewdef>
+
+		<viewdef name="EntoAttributes"
+			type="form"
+			class="edu.ku.brc.specify.datamodel.CollectionObjectAttribute"
+			gettable="edu.ku.brc.af.ui.forms.DataGetterForObj"
+			settable="edu.ku.brc.af.ui.forms.DataSetterForObj">
             <desc><![CDATA[Form For OtherIdentifier]]></desc>
             
             <columnDef>100px,2px,115px,5px,85px,2px,92px,5px,95px,2px,93px,5px,94px,2px,115px,0px,p:g</columnDef>
@@ -343,7 +337,6 @@
                 </row> 
             </rows>
         </viewdef>
-        
-                
-    </viewdefs>
+
+	</viewdefs>
 </viewset>


### PR DESCRIPTION
Hey guys, please see my email about this (Max/Grant). I've just formatted one small views file to start with. You'll see that views and viewdefs are now sorted alphabetically in the file, making them easier to find in big files like common.views. Also, for viewdefs, the name attribute is now on the same line as the opening tag, so if you fold all (Ctrl+k+3 in VS Code), you can quickly see what each one is. 

Let me know if you like it, and if it doesn't break anything. 